### PR TITLE
Show default values in CLIs help

### DIFF
--- a/niizarr/_nii2zarr.py
+++ b/niizarr/_nii2zarr.py
@@ -4,6 +4,7 @@ import json
 import math
 import re
 import sys
+from argparse import ArgumentDefaultsHelpFormatter
 from typing import (
     Literal, Union, List, Optional, Callable, Generator, Any, Tuple
 )
@@ -541,7 +542,7 @@ def nii2zarr(
         elif np.issubdtype(data.dtype, np.bool_):
             fill_value = bool(fill_value)
 
-    
+
     # Fix array shape
     nbatch = data.ndim - 3
     if data.ndim == 5:
@@ -619,7 +620,7 @@ def nii2zarr(
     # Prepare array metadata at each level
     compressor = _make_compressor(compressor, zarr_version=zarr_version,
                                   **compressor_options)
-    
+
     chunk = tuple(chunk) if isinstance(chunk, (list, tuple)) else (chunk,)
     chunk = chunk + chunk[-1:] * max(0, 3 - len(chunk)) + chunk_tc
     chunk = tuple(chunk[i] for i in perm)
@@ -666,7 +667,8 @@ def nii2zarr(
 def cli(args=None):
     """    Command-line entrypoint"""
     parser = argparse.ArgumentParser(
-        'nii2zarr', description='Convert nifti to nifti-zarr.')
+        'nii2zarr', description='Convert nifti to nifti-zarr.',
+        formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         'input', help='Input nifti file.')
     parser.add_argument(

--- a/niizarr/_zarr2nii.py
+++ b/niizarr/_zarr2nii.py
@@ -1,6 +1,7 @@
 import argparse
 import io
 import sys
+from argparse import ArgumentDefaultsHelpFormatter
 from os import PathLike
 from typing import Any, Literal, Optional, Union
 
@@ -289,7 +290,8 @@ def zarr2nii(
 def cli(args=None):
     """Command-line entrypoint"""
     parser = argparse.ArgumentParser(
-        'zarr2nii', description='Convert nifti to nifti-zarr.')
+        'zarr2nii', description='Convert nifti to nifti-zarr.',
+        formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         'input', help='Input zarr directory.')
     parser.add_argument(


### PR DESCRIPTION
I think it's nice to show the defaults to improve usability.

Before:

```
usage: nii2zarr [-h] [--chunk CHUNK] [--unchunk-channels] [--unchunk-time] [--shard SHARD] [--unshard-channels] [--unshard-time] [--levels LEVELS] [--method {gaussian,laplacian}] [--fill FILL]
                [--compressor {blosc,zlib}] [--label] [--no-label] [--no-time] [--no-pyramid-axis {x,y,z}] [--zarr-version {2,3}] [--ome-version {0.4,0.5}]
                input [output]

Convert nifti to nifti-zarr.

positional arguments:
  input                 Input nifti file.
  output                Output zarr directory. When not specified, write to input directory.

options:
  -h, --help            show this help message and exit
  --chunk CHUNK         Spatial chunk size.
  --unchunk-channels    Save all chanels in a single chunk. Unchunk if you want to display all channels as a single RGB layer in neuroglancer. Chunked by default, unless datatype is RGB.
  --unchunk-time        Save all timepoints in a single chunk.Unchunk if you want to display all timepoints as a single RGB layer in neuroglancer. Chunked by default.
  --shard SHARD         Spatial shard size.
  --unshard-channels    Save all channels in a single shard.
  --unshard-time        Save all timepoints in a single shard.
  --levels LEVELS       Number of levels in the pyramid. If -1 (default), use as many levels as possible.
  --method {gaussian,laplacian}
                        Pyramid method.
  --fill FILL           Missing value.
  --compressor {blosc,zlib}
                        Compressor.
  --label               Segmentation volume.
  --no-label            Not a segmentation volume.
  --no-time             No time dimension.
  --no-pyramid-axis {x,y,z}
                        Thick slice axis that should not be downsampled.
  --zarr-version {2,3}  Zarr format version.
  --ome-version {0.4,0.5}
                        OME-Zarr specification version.
```

After

```
usage: nii2zarr [-h] [--chunk CHUNK] [--unchunk-channels] [--unchunk-time] [--shard SHARD] [--unshard-channels] [--unshard-time] [--levels LEVELS] [--method {gaussian,laplacian}] [--fill FILL]
                [--compressor {blosc,zlib}] [--label] [--no-label] [--no-time] [--no-pyramid-axis {x,y,z}] [--zarr-version {2,3}] [--ome-version {0.4,0.5}]
                input [output]

Convert nifti to nifti-zarr.

positional arguments:
  input                 Input nifti file.
  output                Output zarr directory. When not specified, write to input directory. (default: None)

options:
  -h, --help            show this help message and exit
  --chunk CHUNK         Spatial chunk size. (default: 64)
  --unchunk-channels    Save all chanels in a single chunk. Unchunk if you want to display all channels as a single RGB layer in neuroglancer. Chunked by default, unless datatype is RGB. (default: False)
  --unchunk-time        Save all timepoints in a single chunk.Unchunk if you want to display all timepoints as a single RGB layer in neuroglancer. Chunked by default. (default: False)
  --shard SHARD         Spatial shard size. (default: None)
  --unshard-channels    Save all channels in a single shard. (default: False)
  --unshard-time        Save all timepoints in a single shard. (default: False)
  --levels LEVELS       Number of levels in the pyramid. If -1 (default), use as many levels as possible. (default: -1)
  --method {gaussian,laplacian}
                        Pyramid method. (default: gaussian)
  --fill FILL           Missing value. (default: None)
  --compressor {blosc,zlib}
                        Compressor. (default: blosc)
  --label               Segmentation volume. (default: None)
  --no-label            Not a segmentation volume. (default: True)
  --no-time             No time dimension. (default: False)
  --no-pyramid-axis {x,y,z}
                        Thick slice axis that should not be downsampled. (default: None)
  --zarr-version {2,3}  Zarr format version. (default: 2)
  --ome-version {0.4,0.5}
                        OME-Zarr specification version. (default: 0.4)
```