### PR TITLE
[ANH] Accept any patter for level names in zarr group

### DIFF
--- a/niizarr/_nii2zarr.py
+++ b/niizarr/_nii2zarr.py
@@ -11,14 +11,15 @@ from typing import (
 
 import nibabel as nib
 import numpy as np
-import zarr.storage
+import zarr
 from nibabel.nifti1 import Nifti1Header, Nifti1Image
 from nibabel.nifti2 import Nifti2Header, Nifti2Image
 from numpy import ndarray
 from skimage.transform import pyramid_gaussian, pyramid_laplacian
 
 from ._compat import (
-    _make_compressor, _open_zarr, _create_array, _load_nifti_from_stream, pyzarr_version
+    _make_compressor, _open_zarr, _create_array, _load_nifti_from_stream,
+    pyzarr_version
 )
 from ._header import (
     UNITS, DTYPES, INTENTS, INTENTS_P, SLICEORDERS, XFORMS,

--- a/niizarr/_zarr2nii.py
+++ b/niizarr/_zarr2nii.py
@@ -146,30 +146,35 @@ def zarr2nii(
     # prepare metadata
     # ----------------
 
+    # Get OME metadata (if exists)
+    ome = inp.attrs.get("ome", inp.attrs).get("multiscales", None)
+
     # Compute number of levels
     if isinstance(inp, zarr.Group):
         is_group = True
-        inp0 = inp["0"]
-        nb_levels = 0
-        while str(nb_levels) in inp.keys():
-            nb_levels += 1
-        if nb_levels == 0:
-            raise ValueError("This is a Zarr group but not an OME-Zarr.")
-        if level < 0:
-            level = nb_levels + level
-        if level >= nb_levels:
-            raise IndexError(
-                "Pyramid level does not exist. Number of levels:",
-                nb_levels
-            )
+        if ome:
+            levels = ome[0]["datasets"]
+            nb_levels = len(levels)
+        else:
+            nb_levels = 0
+            while str(nb_levels) in inp.keys():
+                nb_levels += 1
+            if nb_levels == 0:
+                raise ValueError("This is a Zarr group but not an OME-Zarr.")
+            if level < 0:
+                level = nb_levels + level
+            if level >= nb_levels:
+                raise IndexError(
+                    "Pyramid level does not exist. Number of levels:",
+                    nb_levels
+                )
+            levels = [{"path": str(level) for level in range(nb_levels)}]
+        inp0 = inp[levels[0]["path"]]
     else:
         is_group = False
         inp0 = inp
         if level not in (0, -1):
             raise IndexError("Pyramid level does not exist -- not an OME zarr")
-
-    # get OME metadata (if exists)
-    ome = inp.attrs.get("ome", inp.attrs).get("multiscales", None)
 
     # --------------------------
     # read or build nifti header
@@ -240,7 +245,7 @@ def zarr2nii(
 
     # load/map array with dask
     if is_group:
-        array = dask.array.from_zarr(inp[f'{level}'])
+        array = dask.array.from_zarr(inp[levels[level]["path"]])
     else:
         array = dask.array.from_zarr(inp)
 


### PR DESCRIPTION
While most OME zarr files have their levels named `{"0", "1", "2", ...}`, it is not required by the standard. The `ngff-zarr` package uses a different convention for level names (`{"scale0/image_name", "scale1/image_name", ...}`). This PR makes `zarr2nii` handle input zarrs with any level naming scheme. It assumes that the first dataset listed in the OME metadata is the highest resolution one (although this could be replaced by an explicit search for the highest resolution level).